### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/config_filter.rs
+++ b/src/config_filter.rs
@@ -553,7 +553,7 @@ impl ConfigFilterRef {
                                    self.transparent_red_value,
                                    self.transparent_green_value,
                                    self.transparent_blue_value]
-                                      .into_iter()
+                                      .iter()
                                       .flat_map(|option| option)
                                       .flat_map(|arr| arr)
                                       .chain(&[egl::EGL_NONE])


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
